### PR TITLE
LibEventSourcing.toc, 'interface' fields now support multiple values per line

### DIFF
--- a/LibEventSourcing.toc
+++ b/LibEventSourcing.toc
@@ -1,6 +1,4 @@
-## Interface: 20502
-## Interface-Classic: 11307
-## Interface-BCC: 20502
+## Interface: 11307, 20502
 ## Title: LibEventSourcing
 ## Author: Sam Mousa
 ## Version: {VERSION}


### PR DESCRIPTION
See: https://warcraft.wiki.gg/wiki/TOC_format#Interface_version

I don't think `interface-classic` etc fields were ever supported.